### PR TITLE
Initialize counters for relevant label combinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -752,7 +752,14 @@ $ while true; do curl -s http://localhost:4000/metrics > /dev/null ; done
 
 ---
 
-**Want to know more?** The
+**Want to know more?** These queries are for calculating the error budget for
+the **latency** SLO by measuring the number of requests slower than 100ms. Now
+try to modify those queries to calculate the error budget for the
+**availability** SLO (requests with `status=~"5.."`), and modify the sample
+application to return a HTTP 5xx error for some requests so you can validate
+the queries.
+
+The
 [Site Reliability Workbook](https://landing.google.com/sre/books/) is a great
 resource on this topic and includes more advanced concepts such as how to alert
 based on SLO burn rate as a way to improve alert precision/recall and

--- a/config/grafana/dashboards/nodejs-sample-app.json
+++ b/config/grafana/dashboards/nodejs-sample-app.json
@@ -17,7 +17,6 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 2,
-  "iteration": 1542969674404,
   "links": [],
   "panels": [
     {
@@ -95,7 +94,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "rate(sample_app_histogram_request_duration_seconds_count{job=\"$job\", instance=\"$instance\", status=~\"5..\"}[30s]) / rate(sample_app_histogram_request_duration_seconds_count{job=\"$job\", instance=\"$instance\"}[30s])",
+          "expr": "sum(rate(sample_app_histogram_request_duration_seconds_count{job=\"$job\", instance=\"$instance\", status=~\"5..\"}[30s])) / sum(rate(sample_app_histogram_request_duration_seconds_count{job=\"$job\", instance=\"$instance\"}[30s]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -105,18 +104,7 @@
       "title": "5xx Error Rate (30s)",
       "type": "singlestat",
       "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "None",
-          "value": "null"
-        },
-        {
-          "op": "=",
-          "text": "None",
-          "value": "0"
-        }
-      ],
+      "valueMaps": [],
       "valueName": "current"
     },
     {
@@ -363,18 +351,7 @@
       "title": "4xx Error Rate (30s)",
       "type": "singlestat",
       "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "None",
-          "value": "null"
-        },
-        {
-          "op": "=",
-          "text": "None",
-          "value": "0"
-        }
-      ],
+      "valueMaps": [],
       "valueName": "current"
     },
     {
@@ -1575,5 +1552,5 @@
   "timezone": "utc",
   "title": "Sample Node.js Application",
   "uid": "000000003",
-  "version": 11
+  "version": 14
 }

--- a/sample-app/index.js
+++ b/sample-app/index.js
@@ -22,6 +22,10 @@ const requestDurationSummary = new prometheusClient.Summary({
   percentiles: [0.5, 0.75, 0.9, 0.95, 0.99]
 });
 
+// Set counters to zero on relevant label combinations
+requestDurationSummary.observe({method: "GET", status: "404"}, 0);
+requestDurationSummary.observe({method: "GET", status: "500"}, 0);
+
 // Histogram metric for measuring request durations
 const requestDurationHistogram = new prometheusClient.Histogram({
   name: 'sample_app_histogram_request_duration_seconds',
@@ -32,6 +36,10 @@ const requestDurationHistogram = new prometheusClient.Histogram({
   // distribution more closely
   buckets:  [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
 });
+
+// Set counters to zero on relevant label combinations
+requestDurationHistogram.observe({method: "GET", status: "404"}, 0);
+requestDurationHistogram.observe({method: "GET", status: "500"}, 0);
 
 // CAUTION: The middlewares must be installed BEFORE the application routes
 // you want to measure.


### PR DESCRIPTION
This allows us to always be able to calculate 4xx and 5xx error rates without having to normalize time series at query time.